### PR TITLE
Add live split-view preview on wide screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -416,3 +416,43 @@ label.errorStar {
 input.error, select.error { 
 	border: 2px solid red; 
 }
+/* ---------------------------------------------------------------------------
+   Live split-view preview (wide screens only; progressive enhancement)
+--------------------------------------------------------------------------- */
+#livePreview { display: none; }
+
+@media (min-width: 1200px) {
+  body.has-live-preview #mainFrame.vertical-center { display: block; min-height: 0; }
+
+  body.has-live-preview #demographicsPage {
+    max-width: min(95vw, 1600px);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: clamp(2rem, 3vw, 3.5rem);
+    align-items: start;
+  }
+
+  body.has-live-preview #demographicsForm { min-width: 0; }
+
+  body.has-live-preview #livePreview {
+    display: block;
+    position: sticky;
+    top: 1rem;
+    max-height: calc(100vh - 2rem);
+    overflow: auto;
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    padding: 1.5rem 1.75rem;
+    font-family: Arial, sans-serif;
+    font-size: 0.8rem;
+    line-height: 1.5;
+  }
+
+  body.has-live-preview #livePreview .frameStyle { border: none; margin: 0 auto; padding: 0; text-align: justify; max-width: 820px; }
+  body.has-live-preview #livePreview h1 { font-size: 1.25rem; }
+  body.has-live-preview #livePreview h3 { font-size: 1rem; margin-top: 1em; }
+  body.has-live-preview #livePreview img { max-height: 70px; max-width: 120px; }
+  body.has-live-preview .livePreview-empty { color: #777; font-style: italic; }
+}

--- a/index.html
+++ b/index.html
@@ -503,5 +503,7 @@
         });
          
     </script>
+     <script src="./preview.js"></script>
+
  </body>
 </html>

--- a/preview.js
+++ b/preview.js
@@ -1,0 +1,61 @@
+/*
+ * Live split-view preview.
+ *
+ * On wide screens (>= 1200px) the consent document is rendered continuously as
+ * the form changes, so the effect of every field, checkbox and dropdown is
+ * visible immediately, next to the form. Progressive enhancement: on narrow
+ * screens nothing changes, and the existing "Generate" / "Print" flow keeps
+ * working exactly as before.
+ *
+ * Reuses the same building blocks as generate(): collectData(), the compiled
+ * Handlebars template, the settings object and the selected institution.
+ */
+(function () {
+  function ready(fn) {
+    if (document.readyState !== 'loading') fn();
+    else document.addEventListener('DOMContentLoaded', fn);
+  }
+
+  function renderLivePreview() {
+    if (typeof settings === 'undefined' || !settings || !settings.institutions) return;
+    var template = Handlebars.templates.template_en;
+    if (!template) return;
+    var out = document.getElementById('livePreview');
+    if (!out) return;
+    var data;
+    try { data = collectData(); } catch (e) { return; }
+    var institution = settings.institutions[data.institution] || {};
+    try {
+      out.innerHTML = template(Object.assign({}, data, institution));
+    } catch (e) {
+      /* incomplete data while typing: keep the last good render */
+    }
+  }
+  window.renderLivePreview = renderLivePreview;
+
+  ready(function () {
+    var page = document.getElementById('demographicsPage');
+    var form = document.getElementById('demographicsForm');
+    if (!page || !form) return;
+
+    var preview = document.createElement('div');
+    preview.id = 'livePreview';
+    preview.setAttribute('aria-label', 'Live preview of the consent document');
+    preview.innerHTML = '<p class="livePreview-empty">A live preview of the consent document appears here and updates as you fill in the form.</p>';
+    page.appendChild(preview);
+    document.body.classList.add('has-live-preview');
+
+    var t;
+    function schedule() { clearTimeout(t); t = setTimeout(renderLivePreview, 150); }
+    form.addEventListener('input', schedule);
+    form.addEventListener('change', schedule);
+    document.addEventListener('click', function (e) {
+      if (e.target.closest && e.target.closest('#btnAddResearcher, .btnRemoveResearcher')) schedule();
+    });
+
+    var iv = setInterval(function () {
+      if (typeof settings !== 'undefined' && settings && settings.institutions) { clearInterval(iv); renderLivePreview(); }
+    }, 200);
+    setTimeout(function () { clearInterval(iv); }, 8000);
+  });
+})();


### PR DESCRIPTION
**Add live split-view preview on wide screens**

On wide screens (≥1200px) the consent document renders continuously beside the form and updates as you change fields, checkboxes, and dropdowns, so the effect of each input is visible immediately without clicking "Generate". Narrow screens are unchanged and the existing Generate/Print flow is untouched.

How: a new preview.js renders the compiled template into a #livePreview pane on each form change (debounced), reusing the existing collectData(), settings, and selected institution; a scoped @media (min-width:1200px) block in css/style.css makes the two-column layout; and one <script> tag in index.html. No new dependencies. The breakpoint and widths are easy to tune.