### PR TITLE
Add Technical University of Munich to the institutions list

### DIFF
--- a/img/logoTUM.svg
+++ b/img/logoTUM.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Ebene_1"
+   x="0px"
+   y="0px"
+   width="408.16"
+   height="212.46684"
+   viewBox="-16.014 -31 408.16 212.46684"
+   enable-background="new -16.014 -31 149 114"
+   xml:space="preserve"
+   sodipodi:docname="TUM_Web_Logo_blau.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"><metadata
+   id="metadata13"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title>TUM_Web_Logo_blau</dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs11" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1920"
+   inkscape:window-height="986"
+   id="namedview9"
+   showgrid="false"
+   fit-margin-top="0"
+   fit-margin-left="0"
+   fit-margin-right="0"
+   fit-margin-bottom="0"
+   inkscape:zoom="1.754386"
+   inkscape:cx="124.61021"
+   inkscape:cy="115.2546"
+   inkscape:window-x="-11"
+   inkscape:window-y="-11"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Ebene_1" />
+<title
+   id="title2">TUM_Web_Logo_blau</title>
+<desc
+   id="desc4">TUM</desc>
+<path
+   fill="#3070b3"
+   d="m 140.54052,-31 v 173.32822 h 44.72985 V -31 H 392.146 V 181.46685 H 353.00738 V 8.138629 H 308.2775 V 181.46685 H 269.13887 V 8.138629 H 224.40902 V 181.46685 H 101.4019 V 8.138629 H 62.26327 V 181.46685 H 23.12462 V 8.138629 H -16.014 V -31 Z"
+   id="path6"
+   style="stroke-width:5.59123" />
+</svg>

--- a/settings.json
+++ b/settings.json
@@ -45,6 +45,13 @@
 			"street":"Pfaffenwaldring 5a",
 			"zip":"70569",
 			"city":"Stuttgart"
+		},
+		"Technical University of Munich": {
+			"name": "Technical University of Munich",
+			"logo": "logoTUM.svg",
+			"street":"Boltzmannstr. 3",
+			"zip":"D - 85748",
+			"city":"Garching"
 		}
 	},
 	"types": [


### PR DESCRIPTION
Adds TUM (Garching campus) as a selectable institution, with its logo (img/logoTUM.svg).