### PR TITLE
Persist form data in sessionStorage instead of a cookie

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,16 +248,6 @@
             downloadAnchorNode.remove();
         }
 
-        function getCookie(name) {
-            var nameEQ = name + "=";
-            var ca = document.cookie.split(';');
-            for(var i=0;i < ca.length;i++) {
-                var c = ca[i];
-                while (c.charAt(0)==' ') c = c.substring(1,c.length);
-                if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
-            }
-            return null;
-        }
 
         var inputKeys = ["title", "duration", "personalData", "storageTime", "purpose", "goal", "departmentHead", "thePIname", "thePIemail", "participants", "monetaryCompensation", "ethicalComittee", "funding"];
         var inputRecord = ["demographics", "contact", "audio", "photos", "videos", "motion", "physiological", "eyetracking", "screenrecording", "notes", "interaction"];
@@ -315,12 +305,19 @@
             $("#hostUrl").attr("href", settings["hostUrl"]);
             $("#hostLogo").attr("src", "img/" + settings["hostLogo"]);
 
-            let cookieData = getCookie("data");
+            let savedData = null;
+            try { savedData = sessionStorage.getItem("icgData"); } catch (e) { /* storage unavailable */ }
 
-            if (cookieData != null){
-                cookieData = JSON.parse(cookieData);
-                fillData(cookieData);
-            } else {
+            let restored = false;
+            if (savedData != null) {
+                try {
+                    fillData(JSON.parse(savedData));
+                    restored = true;
+                } catch (e) {
+                    // corrupt saved data: fall through to a blank form
+                }
+            }
+            if (!restored) {
                 for (let i = 0; i < settings["researcherCount"]; i++){
                     addResearcher();
                 }
@@ -486,9 +483,13 @@
                 var reader = new FileReader();
 
                 reader.onload = function(event) {
-                    var jsonObj = JSON.parse(event.target.result);
-                    data = jsonObj;
-                    fillData(data);
+                    try {
+                        var jsonObj = JSON.parse(event.target.result);
+                        data = jsonObj;
+                        fillData(data);
+                    } catch (e) {
+                        alert("Could not read that file. Please choose a settings JSON exported by this tool.");
+                    }
                 };
 
                 reader.readAsText(event.target.files[0]);

--- a/templating.js
+++ b/templating.js
@@ -77,7 +77,13 @@ function collectData(){
         data["researchers"].push({"name": name, "email": email});
     }
 
-    document.cookie = "data=" + JSON.stringify(data);
+    // Persist the entered data so a reload restores it. sessionStorage keeps it in
+    // the browser only; unlike a cookie it is never sent to the server.
+    try {
+        sessionStorage.setItem("icgData", JSON.stringify(data));
+    } catch (e) {
+        /* storage unavailable (private mode / quota): persistence is best-effort */
+    }
 
     return data;
 }


### PR DESCRIPTION
The entered data was stored in a cookie (document.cookie = "data=" + JSON.stringify(data)), so it was sent to the server on every request (it shows up in request headers and server logs) and was capped at ~4 KB. The tool is entirely client-side, so browser storage is a better fit.

This uses sessionStorage (key "icgData"): it stays in the browser, is never sent to the server, and is scoped to the browser session, so entered study data (e.g. PI and researcher names/emails) does not linger on a shared machine after the tab is closed.

Also wraps the two JSON.parse calls (restoring saved data, and the Load Settings file) in try/catch so a corrupt value no longer leaves the form un-initialized, and removes the now-unused getCookie helper.